### PR TITLE
fixed undefined property bug

### DIFF
--- a/lib/nconf-validator.js
+++ b/lib/nconf-validator.js
@@ -172,6 +172,7 @@ var manualTypeChecks = {
 // These are not directly exposed to users.
 var manualChecks = {
   containsCheck: function(options, x) {
+    x = isString(x) ? x.trim() : '';
     check(x, "one of the possible values: " + options.join(","), validator.isIn(x, options));
   },
   typeCheck: function(fn, x) {

--- a/lib/nconf-validator.js
+++ b/lib/nconf-validator.js
@@ -262,7 +262,7 @@ NConfValidator.prototype.validate = function validate (config, silent) {
   }
   Object.keys(rules).forEach(function (key) {
     var checks = rules[key];
-    var value = config.get(key);
+    var value = config.get(key) || '';
     checks.forEach(function (check) {
       var checkFn = getCheck(check);
       try {


### PR DESCRIPTION
When a validation rule references an undefined property, the validator blows up
